### PR TITLE
Allow relationship advice to be overridden

### DIFF
--- a/copyable.gemspec
+++ b/copyable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~>4.1"
+  spec.add_dependency "activerecord", "~>4.1.0"
 
   spec.add_development_dependency "database_cleaner", "~> 1.4.0"
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/lib/copyable/copyable_extension.rb
+++ b/lib/copyable/copyable_extension.rb
@@ -59,7 +59,9 @@ module Copyable
               # for this brand new model, visit all of the associated models,
               # making new copies according to the instructions in the copyable
               # declaration
-              Declarations::Associations.execute(main.association_list, original_model, new_model, options[:skip_validations])
+
+              skip_associations = options[:skip_associations] || []
+              Declarations::Associations.execute(main.association_list, original_model, new_model, options[:skip_validations], skip_associations)
               # run the after_copy block if it exists
               Declarations::AfterCopy.execute(main.after_copy_block, original_model, new_model)
             ensure

--- a/lib/copyable/declarations/associations.rb
+++ b/lib/copyable/declarations/associations.rb
@@ -6,12 +6,12 @@ module Copyable
 
         # this is the algorithm for copying associated records according to the
         # instructions given in the copyable declaration
-        def execute(association_list, original_model, new_model, skip_validations)
+        def execute(association_list, original_model, new_model, skip_validations, skip_associations)
           @skip_validations = skip_validations
           association_list.each do |assoc_name, advice|
             association = original_model.class.reflections[assoc_name.to_sym]
             check_advice(association, advice, original_model)
-            unless advice == :do_not_copy
+            unless advice == :do_not_copy || skip_associations.include?(assoc_name.to_sym)
               copy_association(association, original_model, new_model)
             end
           end

--- a/lib/copyable/option_checker.rb
+++ b/lib/copyable/option_checker.rb
@@ -1,7 +1,7 @@
 module Copyable
   class OptionChecker
 
-    VALID_OPTIONS = [:override, :skip_validations]
+    VALID_OPTIONS = [:override, :skip_validations, :skip_associations]
     VALID_PRIVATE_OPTIONS = [:__called_recursively]  # for copyable's internal use only
 
     def self.check!(options)
@@ -16,6 +16,10 @@ module Copyable
           message << "  #{opt.inspect}\n"
         end
         raise CopyableError.new(message)
+      end
+      # :skip_associations needs to be an array if it's present
+      if (options[:skip_associations].present? && !options[:skip_associations].is_a?(Array))
+        raise CopyableError.new("When :skip_associations is used, it must be an array")
       end
     end
 

--- a/lib/copyable/version.rb
+++ b/lib/copyable/version.rb
@@ -1,3 +1,3 @@
 module Copyable
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/spec/deep_structure_copy_spec.rb
+++ b/spec/deep_structure_copy_spec.rb
@@ -82,6 +82,13 @@ describe 'complex model hierarchies:' do
        ['moon roof warranty', 'twitter warranty', 'jazz warranty'])
     end
 
+    it 'should skip branches of the tree when directed' do
+      @vehicle2 = @vehicle1.create_copy!(skip_associations: [:copyable_amenities])
+      expect(CopyableVehicle.count).to eq(2)
+      expect(CopyableAmenity.count).to eq(3) # No new ones created
+      expect(CopyableWarranty.count).to eq(3) # Because the amenities weren't copied either
+    end
+
     it 'should create the expected records if copied multiple times' do
       # this test makes sure the SingleCopyEnforcer isn't too eager
       @vehicle1.create_copy!


### PR DESCRIPTION
This adds a `:skip_relationships` option to `#create_copy!`. The argument expects an array of symbols which it uses as a list of relationships to _not_ copy, despite the advice in the model's copyable declaration. This lets us do copies which skip some relationships which might otherwise be defined as copyable.

This will be released as 0.1.0 (it changes the API a non-breaking way).

Note that some changes have been made internally to adapt to changes in ActiveRecord between Rails 4.1 and 4.2. I've changed the ActiveRecord version pin as a result. 