### PR TITLE
Upgrade ActiveRecord version

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,9 @@ The advice must be one of the following:
 
 ## Callbacks
 
-It depends on the situation as to whether you would want a particular callback to be fired when a model is copied.  Since the logic of callbacks is situational, Copyable makes the decision to completely disable all callbacks and observers for the duration of the `create_copy!` method.  The only exception are callbacks and observers related to validation.
-
-To make it easier to reason about the code, and for the sake of being obvious, every copyable declaration *must* include a declaration called `disable_all_callbacks_and_observers_except_validate`.  This declaration itself does not do anything; it exists as documentation.
-
-    copyable do
-      disable_all_callbacks_and_observers_except_validate
-      ...
-    end
-
-
+It depends on the situation as to whether you would want a particular callback to be fired when a model is copied.  Since the logic of callbacks is situational, Copyable makes the decision to bypass callbacks
+when saving the copied models by using raw SQL insert statements during the copy. It will check
+validations unless `skip_validations` is passed to `create_copy`.
 
 ## The After Copy Declaration
 

--- a/copyable.gemspec
+++ b/copyable.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~>4.1.0"
+  spec.add_dependency "activerecord", "~>4.2"
 
   spec.add_development_dependency "database_cleaner", "~> 1.4.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
 end

--- a/lib/copyable/model_hooks.rb
+++ b/lib/copyable/model_hooks.rb
@@ -16,30 +16,33 @@ module Copyable
 
     def self.disable_all_callbacks(klass)
       klass.class_eval do
-        # Don't do it if it was already done
-        return if self.method_defined? :__disabled__run_callbacks
+        return if self.method_defined? :old_save! # Don't do this more than once
 
-        alias_method :__disabled__run_callbacks, :run_callbacks
-        # We are violently duck-punching ActiveRecord because ActiveRecord
-        # gives us no way to turn off callbacks.  My apologies to the
-        # squeamish.
-        def run_callbacks(kind, *args, &block)
-          if block_given?
-            yield
-          else
-            true
-          end
+        @all_callbacks_disabled = true
+        class << self
+          attr_reader :all_callbacks_disabled
+        end
+
+        alias_method :old_save!, :save!
+
+        # Hold my beer while we bypass all the Rails callbacks
+        # in favor of some raw SQL
+        def save!
+          Copyable::Saver.save!(self)
         end
       end
     end
 
     def self.reenable_all_callbacks(klass)
       klass.class_eval do
-        # Only do it if the disabled callbacks are defined
-        return unless self.method_defined? :__disabled__run_callbacks
+        return unless self.method_defined? :old_save! # Don't do this more than once
+        @all_callbacks_disabled = false
+        class << self
+          attr_reader :all_callbacks_disabled
+        end
 
-        alias_method :run_callbacks, :__disabled__run_callbacks
-        remove_method :__disabled__run_callbacks
+        alias_method :save!, :old_save!
+        remove_method :old_save!
       end
     end
 

--- a/lib/copyable/saver.rb
+++ b/lib/copyable/saver.rb
@@ -1,19 +1,27 @@
 module Copyable
   class Saver
 
-    # this is the algorithm for saving the new record
-    def self.save!(new_model, skip_validations)
-      unless skip_validations
-        ModelHooks.reenable!(new_model.class) # we must re-enable or validation does not work
-        if !new_model.valid?(:create)
-          ModelHooks.disable!(new_model.class)
-          raise(ActiveRecord::RecordInvalid.new(new_model))
-        else
-          ModelHooks.disable!(new_model.class)
-        end
-      end
-      new_model.save!
+    def self.direct_sql_insert!(new_model)
+      new_model.send(:_create_record) # bypass all callbacks and validations
     end
 
+    def self.direct_sql_update!(new_model)
+      new_model.send(:_update_record) # bypass all callbacks and validations
+    end
+
+    # this is the algorithm for saving the new record
+    def self.save!(new_model, skip_validations=false)
+      unless skip_validations || new_model.valid?(:create)
+        raise(ActiveRecord::RecordInvalid.new(new_model))
+      end
+
+      if new_model.class.all_callbacks_disabled && new_model.id.nil?
+        self.direct_sql_insert!(new_model)
+      elsif new_model.class.all_callbacks_disabled
+        self.direct_sql_update!(new_model)
+      else
+        new_model.save!
+      end
+    end
   end
 end

--- a/lib/copyable/syntax_checking/association_checker.rb
+++ b/lib/copyable/syntax_checking/association_checker.rb
@@ -10,7 +10,8 @@ module Copyable
     def expected_entries
       all_associations = model_class.reflect_on_all_associations
       required_associations = all_associations.select do |ass|
-        (ass.macro != :belongs_to) && ass.options[:through].blank?
+        !ass.is_a?(ActiveRecord::Reflection::BelongsToReflection) &&
+        !ass.is_a?(ActiveRecord::Reflection::ThroughReflection)
       end
       required_associations.map(&:name).map(&:to_s)
     end

--- a/lib/copyable/version.rb
+++ b/lib/copyable/version.rb
@@ -1,3 +1,3 @@
 module Copyable
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/tasks/copyable.rake
+++ b/lib/tasks/copyable.rake
@@ -39,7 +39,8 @@ task :copyable => :environment do
 
   all_associations = model_class.reflect_on_all_associations
   required_associations = all_associations.select do |ass|
-    (ass.macro != :belongs_to) && ass.options[:through].blank?
+    !ass.is_a?(ActiveRecord::Reflection::BelongsToReflection) &&
+    !ass.is_a?(ActiveRecord::Reflection::ThroughReflection)    
   end
   associations = required_associations.map(&:name).map(&:to_s)
   max_length = associations.map(&:length).max

--- a/spec/helper/test_tables.rb
+++ b/spec/helper/test_tables.rb
@@ -11,14 +11,14 @@ module Copyable
 
           create_table :copyable_albums, force: true do |t|
             t.string :name, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_amenities, force: true do |t|
             t.string   :name
             t.integer  :copyable_vehicle_id
             t.integer  :copyable_owner_id
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_addresses, force: true do |t|
@@ -27,30 +27,30 @@ module Copyable
             t.string   :city,                     null: false
             t.string   :state,                    null: false
             t.integer  :copyable_pet_profile_id,  null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_cars, force: true do |t|
             t.string   :make,   null: false
             t.string   :model,  null: false
             t.integer  :year,   null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_coins, force: true do |t|
             t.string  :kind
             t.integer :year
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_owners, force: true do |t|
             t.string :name, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pet_foods, force: true do |t|
             t.string :name, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pet_foods_pets, force: true, id: false do |t|
@@ -62,31 +62,31 @@ module Copyable
             t.string   :description,     null: false
             t.string   :nickname
             t.integer  :copyable_pet_id, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pet_sitters, force: true do |t|
             t.string  :name, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pet_sitting_patronages, force: true do |t|
             t.integer  :copyable_pet_id,        null: false
             t.integer  :copyable_pet_sitter_id, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pet_tags, force: true do |t|
             t.string   :registered_name, null: false
             t.integer  :copyable_pet_id, null: false
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pets, force: true do |t|
             t.string  :name,        null: false
             t.string  :kind,        null: false
             t.integer :birth_year
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_pictures, force: true do |t|
@@ -94,36 +94,36 @@ module Copyable
             t.integer :imageable_id
             t.string  :imageable_type
             t.integer :picture_album_id
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_products, force: true do |t|
             t.string  :name
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_toys, force: true do |t|
             t.string   :name
             t.string   :kind
             t.integer  :copyable_pet_id
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_trees, force: true do |t|
             t.string  :kind
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_vehicles, force: true do |t|
             t.string  :name
             t.integer :copyable_owner_id
-            t.timestamps
+            t.timestamps null: false
           end
 
           create_table :copyable_warranties, force: true do |t|
             t.string   :name
             t.integer  :copyable_amenity_id
-            t.timestamps
+            t.timestamps null: false
           end
 
         end

--- a/spec/model_hooks_spec.rb
+++ b/spec/model_hooks_spec.rb
@@ -9,85 +9,31 @@ describe Copyable::ModelHooks do
       before(:each) do
         Copyable::ModelHooks.disable!(CopyableTree)
       end
+
       after(:each) do
         Copyable::ModelHooks.reenable!(CopyableTree)
       end
-      it 'should prevent callbacks from executing' do
-        expect {
-          CopyableTree.create!(kind: 'magnolia')
-        }.to_not raise_error
+
+      it 'defines an instance variable on the class' do
+        expect(CopyableTree.all_callbacks_disabled).to eq(true)
       end
+
       it 'should not prevent model actions from executing' do
         expect(CopyableTree.count).to eq(0)
-        CopyableTree.create!(kind: 'magnolia')
-        expect(CopyableTree.count).to eq(1)
       end
     end
 
     describe '.reenable!' do
-      it 'should allow callbacks to execute again' do
-        Copyable::ModelHooks.disable!(CopyableTree)
+      it 'defines an instance variable on the class' do
         Copyable::ModelHooks.reenable!(CopyableTree)
+        expect(CopyableTree.all_callbacks_disabled).to eq(false)
+      end
+
+      it 'should allow callbacks to execute again' do
         expect {
           CopyableTree.create!(kind: 'magnolia')
         }.to raise_error(RuntimeError, "callback2 called")
       end
-    end
-  end
-
-  context 'validations' do
-
-    # Note: the relevant model and observer class is defined in helper/test_models.rb
-
-    describe '.disable!' do
-      before(:each) do
-        Copyable::ModelHooks.disable!(CopyableCoin)
-      end
-      after(:each) do
-        Copyable::ModelHooks.reenable!(CopyableCoin)
-      end
-      it 'should prevent validations from executing' do
-        expect {
-          CopyableCoin.create!(year: -10)
-        }.to_not raise_error
-      end
-      it 'should not prevent model actions from executing' do
-        expect(CopyableCoin.count).to eq(0)
-        CopyableCoin.create!(year: -10)
-        expect(CopyableCoin.count).to eq(1)
-      end
-    end
-
-    describe '.reenable!' do
-      it 'should allow validations to execute again' do
-        Copyable::ModelHooks.disable!(CopyableCoin)
-        Copyable::ModelHooks.reenable!(CopyableCoin)
-        expect {
-          CopyableCoin.create!(year: -10)
-        }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-  end
-
-  describe 'nested disables and enables' do
-    it 'should allow callbacks to execute again' do
-      Copyable::ModelHooks.disable!(CopyableTree)
-      expect { CopyableTree.create!(kind: 'magnolia') }.to_not raise_error
-
-      Copyable::ModelHooks.disable!(CopyableCoin)
-      expect { CopyableCoin.create!(year: -10) }.to_not raise_error
-
-      Copyable::ModelHooks.disable!(CopyableTree)
-      expect { CopyableTree.create!(kind: 'magnolia') }.to_not raise_error
-
-      Copyable::ModelHooks.reenable!(CopyableCoin)
-      expect { CopyableCoin.create!(year: -10) }.to raise_error(ActiveRecord::RecordInvalid)
-
-      Copyable::ModelHooks.reenable!(CopyableTree)
-      expect { CopyableTree.create!(kind: 'magnolia') }.to raise_error(RuntimeError)
-
-      Copyable::ModelHooks.reenable!(CopyableTree)
-      expect { CopyableTree.create!(kind: 'magnolia') }.to raise_error(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
- Changes model hooks to bypass save! temporarily to skip callbacks and
validations
- update association checkers to use new dsl
- also adds `null: false` to timestamps declaration (gets rid of a
deprecation warning)